### PR TITLE
Resolve issue for datatable column created_at and updated_at values displaying in wrong fields.

### DIFF
--- a/app/scripts/controllers/system/DataTableEntryController.js
+++ b/app/scripts/controllers/system/DataTableEntryController.js
@@ -15,7 +15,7 @@
             scope.columnHeaders = [];
             scope.formData = {};
             scope.isViewMode = true;
-            scope.tf = "HH:mm";
+            scope.tf = "HH:MM:ss";
             if(routeParams.mode && routeParams.mode == 'edit'){
                 scope.isViewMode = false;
             }

--- a/app/scripts/controllers/system/MakeDataTableEntryController.js
+++ b/app/scripts/controllers/system/MakeDataTableEntryController.js
@@ -7,7 +7,7 @@
             scope.columnHeaders = [];
             scope.formData = {};
             scope.formDat = {};
-            scope.tf = "HH:mm";
+            scope.tf = "HH:MM:ss";
             resourceFactory.DataTablesResource.getTableDetails({ datatablename: scope.tableName, entityId: scope.entityId, genericResultSet: 'true' }, function (data) {
 
                 var colName = data.columnHeaders[0].columnName;

--- a/app/views/system/makedatatableentry.html
+++ b/app/views/system/makedatatableentry.html
@@ -33,7 +33,7 @@
                                           is-open="opened{{$index}}" class="form-control"/>
                                </div>
                                <div class="form-group">
-                                   <input type="time" placeholder="HH:MM:SS"
+                                   <input step="1" type="time" placeholder="HH:MM:ss"
                                           ng-model="formDat[columnHeader.columnName].time" class="form-control"/>
                                </div>
                            </div>

--- a/app/views/system/viewdatatableentry.html
+++ b/app/views/system/viewdatatableentry.html
@@ -63,7 +63,7 @@
                                            is-open="opened{{$index}}" class="form-control"/>
                                 </div>
                                 <div class="form-group">
-                                    <input type="time" placeholder="HH:MM:SS"
+                                    <input step="1" type="time" placeholder="HH:MM:ss"
                                            ng-model="formDat[columnHeader.columnName].time" class="form-control"/>
                                 </div>
                             </div>


### PR DESCRIPTION
New ticket
https://fiterio.atlassian.net/browse/CI18-447

Description
Revert change which I did for that issue long time ago because it was raising error somewhere else. I fix that old issue with new changes. so both functions working fine
Old one - https://fiterio.atlassian.net/browse/MON-69