### PR TITLE
Update permission for save button in fixed and recurring deposit applications

### DIFF
--- a/app/views/deposits/fixed/newapplication.html
+++ b/app/views/deposits/fixed/newapplication.html
@@ -633,7 +633,7 @@
                         <button id="cancel" ng-click="cancel()" class="btn btn-warning">{{ 'label.button.cancel' | translate }}
                         </button>
                         <button id="save" wz-next class="btn btn-primary" ng-show="data"
-                                has-permission='CREATE_RECURRINGACCOUNT' type="submit">{{
+                                has-permission='CREATE_FIXEDDEPOSITACCOUNT' type="submit">{{
                             'label.button.save' | translate
                             }}
                         </button>

--- a/app/views/deposits/recurring/newapplication.html
+++ b/app/views/deposits/recurring/newapplication.html
@@ -638,7 +638,7 @@
                         <button id="cancel" ng-click="cancel()" class="btn btn-warning">{{ 'label.button.cancel' | translate }}
                         </button>
                         <button id="save" wz-next class="btn btn-primary" ng-show="data"
-                                has-permission='CREATE_RECURRINGACCOUNT' type="submit">{{
+                                has-permission='CREATE_RECURRINGDEPOSITACCOUNT' type="submit">{{
                             'label.button.save' | translate
                             }}
                         </button>


### PR DESCRIPTION
Update permission for save button in fixed and recurring deposit applications
This pull request updates permission checks for the save buttons in the new application forms for fixed and recurring deposit accounts. The changes ensure that the correct permission identifiers are used for each account type.

**Permissions update:**

* Changed the permission required to save a fixed deposit application from `CREATE_RECURRINGACCOUNT` to `CREATE_FIXEDDEPOSITACCOUNT` in `app/views/deposits/fixed/newapplication.html`.
* Changed the permission required to save a recurring deposit application from `CREATE_RECURRINGACCOUNT` to `CREATE_RECURRINGDEPOSITACCOUNT` in `app/views/deposits/recurring/newapplication.html`.
https://fiterio.atlassian.net/browse/FSO-314
