### PR TITLE
FSO-343 Refactor date calculation logic in datepicker module to unable to select past few dates from current date.

### DIFF
--- a/app/scripts/modules/datepicker.js
+++ b/app/scripts/modules/datepicker.js
@@ -143,14 +143,12 @@ angular.module('modified.datepicker', ['strap.position'])
                         numDisplayedFromNextMonth = 0,firstDate = new Date(firstDayOfMonth), numDates = 0;
 
                     if (numDisplayedFromPreviousMonth > 0) {
-                        numDisplayedFromNextMonth = (35 - getDaysInMonth(year, month + 1)) - numDisplayedFromPreviousMonth;
                         firstDate.setDate(-numDisplayedFromPreviousMonth + 1);
                         numDates += numDisplayedFromPreviousMonth; // Previous
-                    }else {
-                        numDisplayedFromNextMonth = 35 - getDaysInMonth(year, month + 1);
                     }
                     numDates += getDaysInMonth(year, month + 1); // Current
-                    numDates += (7 - numDates % 7) % 7; // Next
+                    numDisplayedFromNextMonth = (7 - numDates % 7) % 7; // Next
+                    numDates += numDisplayedFromNextMonth;
 
                     var days = getDates(firstDate, numDates), labels = new Array(7);
                     for (var i = 0; i < numDates; i++) {


### PR DESCRIPTION
we are unable to select 22nd to 24th day of February. Which is affecting posting as at when received.
https://fiterio.atlassian.net/browse/FSO-343

## Description
Describe the changes made and why they were made instead of how they were made.

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
